### PR TITLE
Issue 103 update

### DIFF
--- a/R/helper.R
+++ b/R/helper.R
@@ -691,10 +691,9 @@ splitSignals <- function(x) {
 #' Convert Lotek CMDA log to csv
 #' 
 #' Lotek CMDA logs are exported in TXT, and contain several chunks of
-#' of information. Importantly, the detections are saved in the timezone
-#' of the respective computer, as opposed to the more common UTC standard.
-#' Additionally, the date format also depends on the locale of the computer,
-#' and may therefore be incomprehensible for R without further assistance.
+#' of information. Importantly, the detections may be saved with a GMT offset,
+#' as opposed to the more common UTC standard.
+#' Additionally, the date format isn't the standard yyyy-mm-dd.
 #' 
 #' This function extracts the detections from the CMDA file, converts the
 #' dates to yyyy-mm-dd, binds the time to the date and resets it to UTC, and
@@ -702,7 +701,6 @@ splitSignals <- function(x) {
 #'
 #' @param file the file name.
 #' @param date_format the format used by the computer that generated the file
-#' @param tz the timezone of the computer that generated the file.
 #'
 #' @examples
 #' # create a dummy detections file to read

--- a/man/convertLotekCDMAFile.Rd
+++ b/man/convertLotekCDMAFile.Rd
@@ -4,7 +4,7 @@
 \alias{convertLotekCDMAFile}
 \title{Convert Lotek CMDA log to csv}
 \usage{
-convertLotekCDMAFile(file, date_format, tz)
+convertLotekCDMAFile(file, date_format = "\%m/\%d/\%y")
 }
 \arguments{
 \item{file}{the file name.}
@@ -41,6 +41,9 @@ Bit Rate:           2400 bps
 Code Type:          FSK
 Serial Number:      WHS3K-1234567
 Node ID:            10000
+
+Receiver Settings:
+GMT Correction:     00:00
 
 Decoded Tag Data:
 Date      Time             TOA       Tag ID    Type     Value     Power

--- a/man/convertLotekCDMAFile.Rd
+++ b/man/convertLotekCDMAFile.Rd
@@ -10,18 +10,15 @@ convertLotekCDMAFile(file, date_format = "\%m/\%d/\%y")
 \item{file}{the file name.}
 
 \item{date_format}{the format used by the computer that generated the file}
-
-\item{tz}{the timezone of the computer that generated the file.}
 }
 \value{
 A data frame of standardized detections from the input file.
 }
 \description{
 Lotek CMDA logs are exported in TXT, and contain several chunks of
-of information. Importantly, the detections are saved in the timezone
-of the respective computer, as opposed to the more common UTC standard.
-Additionally, the date format also depends on the locale of the computer,
-and may therefore be incomprehensible for R without further assistance.
+of information. Importantly, the detections may be saved with a GMT offset,
+as opposed to the more common UTC standard.
+Additionally, the date format isn't the standard yyyy-mm-dd.
 }
 \details{
 This function extracts the detections from the CMDA file, converts the

--- a/tests/testthat/test_convertLotekCDMAFile.R
+++ b/tests/testthat/test_convertLotekCDMAFile.R
@@ -12,6 +12,9 @@ Code Type:          FSK
 Serial Number:      WHS3K-1234567
 Node ID:            10000
 
+Receiver Settings:
+GMT Correction:     00:00
+
 Decoded Tag Data:
 Date      Time             TOA       Tag ID    Type     Value     Power
 =======================================================================
@@ -32,8 +35,7 @@ Date      Time      Type                    Details
 sink()
 
 test_that("convertLotekCDMAfile can read lotek cdma log files", {
-	x <- convertLotekCDMAFile(dummy_file, date_format = "%m/%d/%y", 
-                 	          tz = "Europe/Copenhagen")
+	x <- convertLotekCDMAFile(dummy_file)
 	expect_is(x, "data.table")
 })
 
@@ -49,6 +51,9 @@ Bit Rate:           2400 bps
 Code Type:          FSK
 Serial Number:      WHS3K-1234567
 Node ID:            10000
+
+Receiver Settings:
+GMT Correction:     00:00
 
 Decoded Tag Data:
 Date      Time             TOA       Tag ID    Type     Value     Power
@@ -71,8 +76,7 @@ sink()
 
 test_that("convertLotekCDMAfile warns user if any timestamp is bad", {
 	expect_warning(
-		x <- convertLotekCDMAFile(dummy_file2, date_format = "%m/%d/%y", 
-        		                  tz = "Europe/Copenhagen"),
+		x <- convertLotekCDMAFile(dummy_file2),
         paste0("Some timestamp values are NA. This must be fixed before these ",
             "detections are used in an actel analysis."),
       fixed = TRUE)
@@ -93,6 +97,9 @@ Bit Rate:           2400 bps
 Code Type:          FSK
 Serial Number:      WHS3K-12b67
 Node ID:            10000
+
+Receiver Settings:
+GMT Correction:     00:00
 
 Decoded Tag Data:
 Date      Time             TOA       Tag ID    Type     Value     Power
@@ -115,8 +122,7 @@ sink()
 
 test_that("convertLotekCDMAfile warns user if any receiver serial is bad", {
 	expect_warning(
-		x <- convertLotekCDMAFile(dummy_file3, date_format = "%m/%d/%y", 
-        		                  tz = "Europe/Copenhagen"),
+		x <- convertLotekCDMAFile(dummy_file3),
         paste0("Some receiver serial number values are NA. This must be fixed ",
             "before these detections are used in an actel analysis."),
       fixed = TRUE)
@@ -136,6 +142,9 @@ Bit Rate:           2400 bps
 Code Type:           
 Serial Number:      WHS3K-1234567
 Node ID:            10000
+
+Receiver Settings:
+GMT Correction:     00:00
 
 Decoded Tag Data:
 Date      Time             TOA       Tag ID    Type     Value     Power
@@ -158,8 +167,7 @@ sink()
 
 test_that("convertLotekCDMAfile warns user if code space is bad", {
     expect_warning(
-        x <- convertLotekCDMAFile(dummy_file4, date_format = "%m/%d/%y", 
-                                  tz = "Europe/Copenhagen"),
+        x <- convertLotekCDMAFile(dummy_file4),
         paste0("Some code space values are NA. This must be fixed ",
             "before these detections are used in an actel analysis."),
       fixed = TRUE)
@@ -178,6 +186,9 @@ Bit Rate:           2400 bps
 Code Type:          FSK
 Serial Number:      WHS3K-1234567
 Node ID:            10000
+
+Receiver Settings:
+GMT Correction:     00:00
 
 Decoded Tag Data:
 Date      Time             TOA       Tag ID    Type     Value     Power
@@ -200,8 +211,7 @@ sink()
 
 test_that("convertLotekCDMAfile warns user if any signal is bad", {
     expect_warning(
-        x <- convertLotekCDMAFile(dummy_file5, date_format = "%m/%d/%y", 
-                                  tz = "Europe/Copenhagen"),
+        x <- convertLotekCDMAFile(dummy_file5),
         paste0("Some signal values are NA. This must be fixed before these ",
             "detections are used in an actel analysis."),
       fixed = TRUE)


### PR DESCRIPTION
convertLotekCDMAFile should now be able to find and address NAs in the txt log.
Removed the timezone argument, as the TXT log includes the GMT offset used while setting the receiver up.
The date_format argument may not be needed either, if proved that the txt log always uses the same date format.

Progresses #103 
