### PR TITLE
Fixed Preload error when given an object for "distances" instead of a .csv file. Fixes Issue [#134]

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,12 @@
 Package: actel
 Title: Acoustic Telemetry Data Analysis
-Version: 1.3.0.9013
-Authors@R: person("Hugo", "Flávio", role = c("aut", "cre"), email = "hflavio@dal.ca", comment = c(ORCID = "0000-0002-5174-1197"))
+Version: 1.3.0.9014
+Authors@R: c(
+    person("Hugo", "Flávio", role = c("aut", "cre"), 
+           email = "hflavio@dal.ca", comment = c(ORCID = "0000-0002-5174-1197")),
+    person("Devon", "Smith", role = c("ctb"), 
+           email = "smithd0@unbc.ca", comment = c(ORCID = "0009-0005-3954-6355"))
+    )
 Description: Designed for studies where animals tagged with acoustic tags are expected
     to move through receiver arrays. This package combines the advantages of automatic sorting and checking 
     of animal movements with the possibility for user intervention on tags that deviate from expected 

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@ Fixes:
   * Fix crash when running residency analysis and a group of animals is never detected (issue [#114](https://github.com/hugomflavio/actel/issues/114)).
   * Remove "Index" column from residency list tables with one row (issue [#93](https://github.com/hugomflavio/actel/issues/93)).
   * Fix silent bug causing `time.ratios` (residency analysis) to occasionally calculate exceedingly long times when using `timestep = hours` (issue [#89](https://github.com/hugomflavio/actel/issues/89)).
+  * Fixed `loadDistances()` issue where R objects were causing errors but .csv files were non-issue (issue [#134](https://github.com/hugomflavio/actel/issues/134)).
 
 Enhancements:
   * Improve timestamp handling when importing data through `preload()` (issue [#94](https://github.com/hugomflavio/actel/issues/94)).

--- a/R/load.R
+++ b/R/load.R
@@ -641,11 +641,11 @@ setSpatialStandards <- function(input){
 #' Load distances matrix
 #'
 #' @param input Either a path to a csv file containing a distances matrix, 
-#' or an R object containing a distances matrix.
+#'  or an R object containing a distances matrix.
 #' @param spatial A list of spatial objects in the study area.
 #'
 #' @return A matrix of the distances (in metres) between stations 
-#' (if a 'distances.csv' is present)
+#'  (if a 'distances.csv' is present)
 #'
 #' @keywords internal
 #'
@@ -671,7 +671,6 @@ loadDistances <- function(input = "distances.csv", spatial) {
       dist.mat <- NULL
     }
   } else {
-    
     # Ensure the input is a matrix, 
     # in case the user provided the data in a non-base format
     dist.mat <- as.matrix(input)
@@ -721,52 +720,52 @@ loadDistances <- function(input = "distances.csv", spatial) {
       colnames(dist.mat)[ncol(dist.mat)] <- "unspecified"
       rownames(dist.mat)[nrow(dist.mat)] <- "unspecified"
     }
-    if (!invalid.dist && sum(nrow(spatial$stations), 
+    if (!invalid.dist && sum(nrow(spatial$stations),
                              nrow(spatial$release.sites)) != nrow(dist.mat)) {
-      appendTo(c("Screen", 
-                 "Report", 
-                 "Warning"), 
-               paste0("The number of spatial points does not match the number", 
-                      " of rows in the distances matrix. Deactivating speed", 
+      appendTo(c("Screen",
+                 "Report",
+                 "Warning"),
+               paste0("The number of spatial points does not match the number",
+                      " of rows in the distances matrix. Deactivating speed",
                       " calculations to avoid function failure."))
-      message(" Number of stations and release sites listed: ", 
+      message(" Number of stations and release sites listed: ",
               sum(nrow(spatial$stations), nrow(spatial$release.sites)))
-      message(" Number of rows/columns in the distance matrix: ", 
+      message(" Number of rows/columns in the distance matrix: ",
               nrow(dist.mat))
       invalid.dist <- TRUE
     }
-    if (!invalid.dist) { 
-      spatial_names <- c(spatial$stations$Standard.name, 
-                         spatial$release.sites$Standard.name) 
+    if (!invalid.dist) {
+      spatial_names <- c(spatial$stations$Standard.name,
+                         spatial$release.sites$Standard.name)
       if (any(!matchl(spatial_names, colnames(dist.mat)))) {
-      appendTo(c("Screen", 
-                 "Report", 
-                 "Warning"), 
-               paste0("Some stations and/or release sites are not", 
-                      " present in the distances matrix. Deactivating speed", 
-                      " calculations to avoid function failure."))
-      link <- !matchl(spatial$release.sites$Standard.name, colnames(dist.mat))
-      missing.releases <- spatial$release.sites$Standard.name[link]
-      link <- !matchl(spatial$stations$Standard.name, colnames(dist.mat))
-      missing.stations <- spatial$stations$Standard.name[link]
-      if (length(missing.releases) > 0) {
-        message(paste0(" Release sites missing: '", 
-                       paste(missing.releases, collapse = "', '")))
+        appendTo(c("Screen",
+                   "Report",
+                   "Warning"),
+                 paste0("Some stations and/or release sites are not",
+                        " present in the distances matrix. Deactivating speed",
+                        " calculations to avoid function failure."))
+        link <- !matchl(spatial$release.sites$Standard.name, colnames(dist.mat))
+        missing.releases <- spatial$release.sites$Standard.name[link]
+        link <- !matchl(spatial$stations$Standard.name, colnames(dist.mat))
+        missing.stations <- spatial$stations$Standard.name[link]
+        if (length(missing.releases) > 0) {
+          message(paste0(" Release sites missing: '",
+                         paste(missing.releases, collapse = "', '")))
         }
-      if (length(missing.stations) > 0) {
-        message(paste0(" Stations missing: '", 
-                       paste(missing.stations, collapse = "', '")))
+        if (length(missing.stations) > 0) {
+          message(paste0(" Stations missing: '",
+                         paste(missing.stations, collapse = "', '")))
         }
-      invalid.dist <- TRUE
+        invalid.dist <- TRUE
+      }
     }
-  }
-    } else {
+  } else {
     dist.mat <- NA
   }
-    attributes(dist.mat)$valid <- !invalid.dist
+
+  attributes(dist.mat)$valid <- !invalid.dist
   return(dist.mat)
-  
-  }
+}
 
 
 #' Load deployments file and Check the structure

--- a/R/load.R
+++ b/R/load.R
@@ -640,10 +640,12 @@ setSpatialStandards <- function(input){
 
 #' Load distances matrix
 #'
-#' @param input Either a path to a csv file containing a distances matrix, or an R object containing a distances matrix.
+#' @param input Either a path to a csv file containing a distances matrix, 
+#' or an R object containing a distances matrix.
 #' @param spatial A list of spatial objects in the study area.
 #'
-#' @return A matrix of the distances (in metres) between stations (if a 'distances.csv' is present)
+#' @return A matrix of the distances (in metres) between stations 
+#' (if a 'distances.csv' is present)
 #'
 #' @keywords internal
 #'
@@ -658,27 +660,28 @@ loadDistances <- function(input = "distances.csv", spatial) {
                paste0("M: File '", 
                       input, "' found, activating speed calculations."))
       dist.mat <- as.matrix(read.csv(input, row.names = 1, check.names = FALSE))
-      if (ncol(dist.mat) == 1){
-        warning(paste0("Only one column was identified in '", 
+      if (ncol(dist.mat) == 1) {
+        warning("Only one column was identified in '", 
                 input, "'. If this seems wrong,", 
-                " please make sure that the values are separated using commas."), 
+                " please make sure that the values are separated using commas.", 
                 immediate. = TRUE, 
-                call. = FALSE)}
+                call. = FALSE)
+        }
     } else {
       dist.mat <- NULL
     }
-  } else{
-    dist.mat <- as.matrix(input)
-  } 
+  } else {
+    
     # Ensure the input is a matrix, 
     # in case the user provided the data in a non-base format
-  
+    dist.mat <- as.matrix(input)
+  } 
 
   if (!is.null(dist.mat)) {
     rownames(dist.mat) <- gsub(" ", "_", rownames(dist.mat))
     colnames(dist.mat) <- gsub(" ", "_", colnames(dist.mat))
     invalid.dist <- FALSE
-    if (nrow(dist.mat) != ncol(dist.mat)){
+    if (nrow(dist.mat) != ncol(dist.mat)) {
       appendTo(c("Screen", 
                  "Report", 
                  "Warning"), 
@@ -687,23 +690,30 @@ loadDistances <- function(input = "distances.csv", spatial) {
                       " to avoid function failure."))
       invalid.dist <- TRUE
     }
-    if (!invalid.dist && any(link <- is.na(match(rownames(dist.mat), 
-                                                 colnames(dist.mat))))) {
-      appendTo(c("Screen", 
-                 "Report", 
-                 "Warning"), 
-               paste0("The column and row names in the distances matrix do not", 
-                      " match each other. Deactivating speed calculations to", 
-                      " avoid function failure."))
-      message(paste0("   Row names missing in the columns: '", 
-                     paste(rownames(dist.mat)[link], 
-                           collapse = "', '"), "'."))
-      if (any(link <- is.na(match(colnames(dist.mat), rownames(dist.mat))))){
-        message(paste0("   Column names missing in the rows: '", 
-                       paste(colnames(dist.mat)[link], 
-                             collapse = "', '"), "'."))}
-      invalid.dist <- TRUE
+    if (!invalid.dist) {
+      row_link <- is.na(match(rownames(dist.mat), colnames(dist.mat)))
+      col_link <- is.na(match(colnames(dist.mat), rownames(dist.mat)))
+      if (any(row_link) | any(col_link)) {
+        appendTo(c("Screen",
+                   "Report",
+                   "Warning"),
+              paste0("The column and row names in the distances matrix do not",
+                      " match each other. Deactivating speed calculations to",
+                        " avoid function failure."))
+        if (any(row_link)) {
+          message(paste0(" Row names missing in the columns: '",
+                         paste(rownames(dist.mat)[row_link],
+                               collapse = "', '"), "'."))
+        }
+        if (any(col_link)) {
+          message(paste0(" Column names missing in the rows: '",
+                         paste(colnames(dist.mat)[col_link],
+                               collapse = "', '"), "'."))
+        }
+        invalid.dist <- TRUE
+      }
     }
+
     # Failsafe for the case of unspecified release sites
     if (any(grepl("^unspecified$", spatial$release.sites$Standard.name))) {
       dist.mat <- rbind(dist.mat, NA)
@@ -719,16 +729,16 @@ loadDistances <- function(input = "distances.csv", spatial) {
                paste0("The number of spatial points does not match the number", 
                       " of rows in the distances matrix. Deactivating speed", 
                       " calculations to avoid function failure."))
-      message("   Number of stations and release sites listed: ", 
+      message(" Number of stations and release sites listed: ", 
               sum(nrow(spatial$stations), nrow(spatial$release.sites)))
-      message("   Number of rows/columns in the distance matrix: ", 
+      message(" Number of rows/columns in the distance matrix: ", 
               nrow(dist.mat))
       invalid.dist <- TRUE
     }
-    if (!invalid.dist && 
-        (any(!matchl(spatial$stations$Standard.name, colnames(dist.mat))) | 
-         any(!matchl(spatial$release.sites$Standard.name, 
-                     colnames(dist.mat))))){
+    if (!invalid.dist) { 
+      spatial_names <- c(spatial$stations$Standard.name, 
+                         spatial$release.sites$Standard.name) 
+      if (any(!matchl(spatial_names, colnames(dist.mat)))) {
       appendTo(c("Screen", 
                  "Report", 
                  "Warning"), 
@@ -739,21 +749,24 @@ loadDistances <- function(input = "distances.csv", spatial) {
       missing.releases <- spatial$release.sites$Standard.name[link]
       link <- !matchl(spatial$stations$Standard.name, colnames(dist.mat))
       missing.stations <- spatial$stations$Standard.name[link]
-      if (length(missing.releases) > 0){
-        message(paste0("   Release sites missing: '", 
-                       paste(missing.releases, collapse = "', '")))}
-      if (length(missing.stations) > 0){
-        message(paste0("   Stations missing: '", 
-                       paste(missing.stations, collapse = "', '")))}
+      if (length(missing.releases) > 0) {
+        message(paste0(" Release sites missing: '", 
+                       paste(missing.releases, collapse = "', '")))
+        }
+      if (length(missing.stations) > 0) {
+        message(paste0(" Stations missing: '", 
+                       paste(missing.stations, collapse = "', '")))
+        }
       invalid.dist <- TRUE
     }
-  } else {
+  }
+    } else {
     dist.mat <- NA
   }
-  attributes(dist.mat)$valid <- !invalid.dist
-  
+    attributes(dist.mat)$valid <- !invalid.dist
   return(dist.mat)
-}
+  
+  }
 
 
 #' Load deployments file and Check the structure

--- a/R/load.R
+++ b/R/load.R
@@ -660,7 +660,11 @@ loadDistances <- function(input = "distances.csv", spatial) {
       dist.mat <- NULL
     }
   } else {
-    dist.mat <- as.matrix(input)
+    # Ensure the input is a data frame, 
+    # in case the user provided the data in a non-base format
+    # Some of the code downstream won't work with a matrix,  
+    # so the input can't be converted to a matrix right away
+    dist.mat <- as.data.frame(input)
   }
 
   if (!is.null(dist.mat)) {
@@ -705,6 +709,9 @@ loadDistances <- function(input = "distances.csv", spatial) {
     dist.mat <- NA
   }
   attributes(dist.mat)$valid <- !invalid.dist
+  
+  dist.mat <- as.matrix(dist.mat)
+  
   return(dist.mat)
 }
 

--- a/R/load.R
+++ b/R/load.R
@@ -633,13 +633,14 @@ setSpatialStandards <- function(input){
   input$Standard.name <- as.character(input$Station.name)
   input$Standard.name <- gsub(" ", "_", input$Standard.name)
   link <- input$Type == "Hydrophone"
-  input$Standard.name[link] <- paste0("St.", seq_len(sum(input$Type == "Hydrophone")))
+  input$Standard.name[link] <- paste0("St.", 
+                                      seq_len(sum(input$Type == "Hydrophone")))
   return(input)
 }
 
 #' Load distances matrix
 #'
-#' @param input A matrix of distances, to be loaded rather than a file.
+#' @param input Either a path to a csv file containing a distances matrix, or an R object containing a distances matrix.
 #' @param spatial A list of spatial objects in the study area.
 #'
 #' @return A matrix of the distances (in metres) between stations (if a 'distances.csv' is present)
@@ -652,65 +653,104 @@ loadDistances <- function(input = "distances.csv", spatial) {
   invalid.dist <- TRUE
   if (is.character(input)) {
     if (file.exists(input)) {
-      appendTo(c("Screen", "Report"), paste0("M: File '", input, "' found, activating speed calculations."))
-      dist.mat <- read.csv(input, row.names = 1, check.names = FALSE)
-      if (ncol(dist.mat) == 1)
-        warning("Only one column was identified in '", input, "'. If this seems wrong, please make sure that the values are separated using commas.", immediate. = TRUE, call. = FALSE)
+      appendTo(c("Screen", 
+                 "Report"), 
+               paste0("M: File '", 
+                      input, "' found, activating speed calculations."))
+      dist.mat <- as.matrix(read.csv(input, row.names = 1, check.names = FALSE))
+      if (ncol(dist.mat) == 1){
+        warning(paste0("Only one column was identified in '", 
+                input, "'. If this seems wrong,", 
+                " please make sure that the values are separated using commas."), 
+                immediate. = TRUE, 
+                call. = FALSE)}
     } else {
       dist.mat <- NULL
     }
-  } else {
-    # Ensure the input is a data frame, 
+  } else{
+    dist.mat <- as.matrix(input)
+  } 
+    # Ensure the input is a matrix, 
     # in case the user provided the data in a non-base format
-    # Some of the code downstream won't work with a matrix,  
-    # so the input can't be converted to a matrix right away
-    dist.mat <- as.data.frame(input)
-  }
+  
 
   if (!is.null(dist.mat)) {
     rownames(dist.mat) <- gsub(" ", "_", rownames(dist.mat))
     colnames(dist.mat) <- gsub(" ", "_", colnames(dist.mat))
     invalid.dist <- FALSE
     if (nrow(dist.mat) != ncol(dist.mat)){
-      appendTo(c("Screen", "Report", "Warning"), "The distances matrix appears to be missing data (ncol != nrow). Deactivating speed calculations to avoid function failure.")
+      appendTo(c("Screen", 
+                 "Report", 
+                 "Warning"), 
+               paste0("The distances matrix appears to be missing data", 
+                      " (ncol != nrow). Deactivating speed calculations", 
+                      " to avoid function failure."))
       invalid.dist <- TRUE
     }
-    if (!invalid.dist && any(link <- is.na(match(rownames(dist.mat), colnames(dist.mat))))) {
-      appendTo(c("Screen", "Report", "Warning"), "The column and row names in the distances matrix do not match each other. Deactivating speed calculations to avoid function failure.")
-      message(paste0("   Row names missing in the columns: '", paste(rownames(dist.mat)[link], collapse = "', '"), "'."))
-      if (any(link <- is.na(match(colnames(dist.mat), rownames(dist.mat)))))
-        message(paste0("   Column names missing in the rows: '", paste(colnames(dist.mat)[link], collapse = "', '"), "'."))
+    if (!invalid.dist && any(link <- is.na(match(rownames(dist.mat), 
+                                                 colnames(dist.mat))))) {
+      appendTo(c("Screen", 
+                 "Report", 
+                 "Warning"), 
+               paste0("The column and row names in the distances matrix do not", 
+                      " match each other. Deactivating speed calculations to", 
+                      " avoid function failure."))
+      message(paste0("   Row names missing in the columns: '", 
+                     paste(rownames(dist.mat)[link], 
+                           collapse = "', '"), "'."))
+      if (any(link <- is.na(match(colnames(dist.mat), rownames(dist.mat))))){
+        message(paste0("   Column names missing in the rows: '", 
+                       paste(colnames(dist.mat)[link], 
+                             collapse = "', '"), "'."))}
       invalid.dist <- TRUE
     }
     # Failsafe for the case of unspecified release sites
     if (any(grepl("^unspecified$", spatial$release.sites$Standard.name))) {
-      dist.mat[nrow(dist.mat) + 1, ] <- NA
-      dist.mat[, ncol(dist.mat) + 1] <- NA
+      dist.mat <- rbind(dist.mat, NA)
+      dist.mat <- cbind(dist.mat, NA)
       colnames(dist.mat)[ncol(dist.mat)] <- "unspecified"
       rownames(dist.mat)[nrow(dist.mat)] <- "unspecified"
     }
-    if (!invalid.dist && sum(nrow(spatial$stations), nrow(spatial$release.sites)) != nrow(dist.mat)) {
-      appendTo(c("Screen", "Report", "Warning"), "The number of spatial points does not match the number of rows in the distances matrix. Deactivating speed calculations to avoid function failure.")
-      message("   Number of stations and release sites listed: ", sum(nrow(spatial$stations), nrow(spatial$release.sites)))
-      message("   Number of rows/columns in the distance matrix: ", nrow(dist.mat))
+    if (!invalid.dist && sum(nrow(spatial$stations), 
+                             nrow(spatial$release.sites)) != nrow(dist.mat)) {
+      appendTo(c("Screen", 
+                 "Report", 
+                 "Warning"), 
+               paste0("The number of spatial points does not match the number", 
+                      " of rows in the distances matrix. Deactivating speed", 
+                      " calculations to avoid function failure."))
+      message("   Number of stations and release sites listed: ", 
+              sum(nrow(spatial$stations), nrow(spatial$release.sites)))
+      message("   Number of rows/columns in the distance matrix: ", 
+              nrow(dist.mat))
       invalid.dist <- TRUE
     }
-    if (!invalid.dist && (any(!matchl(spatial$stations$Standard.name, colnames(dist.mat))) | any(!matchl(spatial$release.sites$Standard.name, colnames(dist.mat))))) {
-      appendTo(c("Screen", "Report", "Warning"), "Some stations and/or release sites are not present in the distances matrix. Deactivating speed calculations to avoid function failure.")
-      missing.releases <- spatial$release.sites$Standard.name[!matchl(spatial$release.sites$Standard.name, colnames(dist.mat))]
-      missing.stations <- spatial$stations$Standard.name[!matchl(spatial$stations$Standard.name, colnames(dist.mat))]
-      if (length(missing.releases) > 0)
-        message(paste0("   Release sites missing: '", paste(missing.releases, collapse = "', '")))
-      if (length(missing.stations) > 0)
-        message(paste0("   Stations missing: '", paste(missing.stations, collapse = "', '")))
+    if (!invalid.dist && 
+        (any(!matchl(spatial$stations$Standard.name, colnames(dist.mat))) | 
+         any(!matchl(spatial$release.sites$Standard.name, 
+                     colnames(dist.mat))))){
+      appendTo(c("Screen", 
+                 "Report", 
+                 "Warning"), 
+               paste0("Some stations and/or release sites are not", 
+                      " present in the distances matrix. Deactivating speed", 
+                      " calculations to avoid function failure."))
+      link <- !matchl(spatial$release.sites$Standard.name, colnames(dist.mat))
+      missing.releases <- spatial$release.sites$Standard.name[link]
+      link <- !matchl(spatial$stations$Standard.name, colnames(dist.mat))
+      missing.stations <- spatial$stations$Standard.name[link]
+      if (length(missing.releases) > 0){
+        message(paste0("   Release sites missing: '", 
+                       paste(missing.releases, collapse = "', '")))}
+      if (length(missing.stations) > 0){
+        message(paste0("   Stations missing: '", 
+                       paste(missing.stations, collapse = "', '")))}
       invalid.dist <- TRUE
     }
   } else {
     dist.mat <- NA
   }
   attributes(dist.mat)$valid <- !invalid.dist
-  
-  dist.mat <- as.matrix(dist.mat)
   
   return(dist.mat)
 }

--- a/man/actel.Rd
+++ b/man/actel.Rd
@@ -88,5 +88,10 @@ for!
 \author{
 \strong{Maintainer}: Hugo Flávio \email{hflavio@dal.ca} (\href{https://orcid.org/0000-0002-5174-1197}{ORCID})
 
+Other contributors:
+\itemize{
+  \item Devon Smith \email{smithd0@unbc.ca} (\href{https://orcid.org/0009-0005-3954-6355}{ORCID}) [contributor]
+}
+
 }
 \keyword{internal}

--- a/man/loadDistances.Rd
+++ b/man/loadDistances.Rd
@@ -7,7 +7,7 @@
 loadDistances(input = "distances.csv", spatial)
 }
 \arguments{
-\item{input}{A matrix of distances, to be loaded rather than a file.}
+\item{input}{Either a path to a csv file containing a distances matrix, or an R object containing a distances matrix.}
 
 \item{spatial}{A list of spatial objects in the study area.}
 }

--- a/man/loadDistances.Rd
+++ b/man/loadDistances.Rd
@@ -7,12 +7,14 @@
 loadDistances(input = "distances.csv", spatial)
 }
 \arguments{
-\item{input}{Either a path to a csv file containing a distances matrix, or an R object containing a distances matrix.}
+\item{input}{Either a path to a csv file containing a distances matrix,
+or an R object containing a distances matrix.}
 
 \item{spatial}{A list of spatial objects in the study area.}
 }
 \value{
-A matrix of the distances (in metres) between stations (if a 'distances.csv' is present)
+A matrix of the distances (in metres) between stations
+(if a 'distances.csv' is present)
 }
 \description{
 Load distances matrix


### PR DESCRIPTION
Added new code to fix preload() from giving an error when it called on the loadDistances() function. The issue was due to R objects being made into a matrix while .csv's stayed as a data.frame.

Changed code to make R object distance matrix's be data.frames and return as a matrix once complete. 