### PR TITLE
Issue #142 return dist.mat even if it is invalid

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: actel
 Title: Acoustic Telemetry Data Analysis
-Version: 1.3.0.9017
+Version: 1.3.0.9018
 Authors@R: c(
     person("Hugo", "Flávio", role = c("aut", "cre"),
            email = "hflavio@dal.ca", comment = c(ORCID = "0000-0002-5174-1197")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -25,7 +25,7 @@ Enhancements:
   * New `plotDot()` function to help users inspect their spatial.txt files (issue [#55](https://github.com/hugomflavio/actel/issues/55)).
   * Improved internal mechanisms for message/warning/debug/stop reporting. new internal function `event()` replaces the old `appendTo()`, `stopAndReport()`, and `emergencyBreak()` (issue [#135](https://github.com/hugomflavio/actel/issues/135))
   * Added the ability to use output of `loadSpatial()` as 'starters' for `distancesMatrix()` when 'actel' is 'TRUE'. This allows a user to input their spatial.csv if located in a separate working directory (issue [#133](https://github.com/hugomflavio/actel/issues/133))
-  * Distance matrix is now retained in the output of explore, residency, and migration analysis. When the distance matrix is not available or invalid, NA will be denoted in the output. (issue [#142](https://github.com/hugomflavio/actel/issues/142))
+  * Distance matrix is now retained in the output of `explore()`, `residency()`, and `migration()` analysis. When the distance matrix is not available or invalid, NA will be denoted in the output. (issue [#142](https://github.com/hugomflavio/actel/issues/142))
 
 ## actel 1.3.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@ Enhancements:
   * New `plotDot()` function to help users inspect their spatial.txt files (issue [#55](https://github.com/hugomflavio/actel/issues/55)).
   * Improved internal mechanisms for message/warning/debug/stop reporting. new internal function `event()` replaces the old `appendTo()`, `stopAndReport()`, and `emergencyBreak()` (issue [#135](https://github.com/hugomflavio/actel/issues/135))
   * Added the ability to use output of `loadSpatial()` as 'starters' for `distancesMatrix()` when 'actel' is 'TRUE'. This allows a user to input their spatial.csv if located in a separate working directory (issue [#133](https://github.com/hugomflavio/actel/issues/133))
+  * Distance matrix is now retained in the output of explore, residency, and migration analysis. When the distance matrix is not available or invalid, NA will be denoted in the output. (issue [#142](https://github.com/hugomflavio/actel/issues/142))
 
 ## actel 1.3.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -25,7 +25,7 @@ Enhancements:
   * New `plotDot()` function to help users inspect their spatial.txt files (issue [#55](https://github.com/hugomflavio/actel/issues/55)).
   * Improved internal mechanisms for message/warning/debug/stop reporting. new internal function `event()` replaces the old `appendTo()`, `stopAndReport()`, and `emergencyBreak()` (issue [#135](https://github.com/hugomflavio/actel/issues/135))
   * Added the ability to use output of `loadSpatial()` as 'starters' for `distancesMatrix()` when 'actel' is 'TRUE'. This allows a user to input their spatial.csv if located in a separate working directory (issue [#133](https://github.com/hugomflavio/actel/issues/133))
-  * Distance matrix is now retained in the output of `explore()`, `residency()`, and `migration()` analysis. When the distance matrix is not available or invalid, NA will be denoted in the output. (issue [#142](https://github.com/hugomflavio/actel/issues/142))
+  * Distance matrix is now retained in the output of `explore()`, `residency()`, and `migration()` analysis when invalid. Additionally, if the distance matrix is not available NA will be denoted in the output. (issue [#142](https://github.com/hugomflavio/actel/issues/142))
 
 ## actel 1.3.0
 

--- a/R/explore.R
+++ b/R/explore.R
@@ -686,7 +686,7 @@ explore <- function(
                  valid.movements = valid.movements,
                  times = times,
                  rsp.info = rsp.info,
-                 dist.mat <- dist.mat)
+                 dist.mat = dist.mat)
 
  event(type = "Screen",
        "M: Analysis completed!")

--- a/R/explore.R
+++ b/R/explore.R
@@ -520,12 +520,9 @@ explore <- function(
   if (decision == "y") { # nocov start
    event(type = c("screen", "report"),
          paste0("M: Saving results as '", resultsname, "'."))
-    if (attributes(dist.mat)$valid)
-      save(bio, detections, valid.detections, spatial, deployments, arrays,
-        movements, valid.movements, times, rsp.info, dist.mat, file = resultsname)
-    else
-      save(bio, detections, valid.detections, spatial, deployments, arrays,
-        movements, valid.movements, times, rsp.info, file = resultsname)
+   save(bio, detections, valid.detections, spatial, deployments, arrays,
+        movements, valid.movements, times, rsp.info, dist.mat, 
+        file = resultsname)
   } else {
    event(type = c("screen", "report"),
          paste0("M: Skipping saving of the results."))
@@ -688,10 +685,8 @@ explore <- function(
                  movements = movements,
                  valid.movements = valid.movements,
                  times = times,
-                 rsp.info = rsp.info)
-
-  if (attributes(dist.mat)$valid)
-    output$dist.mat <- dist.mat
+                 rsp.info = rsp.info,
+                 dist.mat <- dist.mat)
 
  event(type = "Screen",
        "M: Analysis completed!")

--- a/R/migration.R
+++ b/R/migration.R
@@ -1058,7 +1058,7 @@ migration <- function(
                  intra.array.CJS = intra.array.CJS,
                  times = times,
                  rsp.info = rsp.info,
-                 dist.mat <- dist.mat)
+                 dist.mat = dist.mat)
 
   event(type = "screen",
         "M: Analysis completed!")

--- a/R/migration.R
+++ b/R/migration.R
@@ -831,19 +831,11 @@ migration <- function(
     # in coding style (actel 2.0).
     section.movements <- secmoves
     intra.array.matrices <- intra_mats
-    if (attributes(dist.mat)$valid) {
-      save(detections, valid.detections, spatial, deployments, arrays,
-           movements, valid.movements, section.movements, status.df,
-           section.overview, group.overview, release.overview, matrices,
-           overall.CJS, intra.array.matrices, intra.array.CJS, times,
-           rsp.info, dist.mat, file = resultsname)
-    } else {
-      save(detections, valid.detections, spatial, deployments, arrays,
-           movements, valid.movements, section.movements, status.df,
-           section.overview, group.overview, release.overview, matrices,
-           overall.CJS, intra.array.matrices, intra.array.CJS, times,
-           rsp.info, file = resultsname)
-    }
+    save(detections, valid.detections, spatial, deployments, arrays,
+         movements, valid.movements, section.movements, status.df,
+         section.overview, group.overview, release.overview, matrices,
+         overall.CJS, intra.array.matrices, intra.array.CJS, times,
+         rsp.info, dist.mat, file = resultsname)
   } else { # nocov end
     event(type = c("screen", "report"),
           "M: Skipping saving of the results.")
@@ -1065,11 +1057,8 @@ migration <- function(
                  intra.array.matrices = intra_mats,
                  intra.array.CJS = intra.array.CJS,
                  times = times,
-                 rsp.info = rsp.info)
-
-  if (attributes(dist.mat)$valid) {
-    output$dist.mat <- dist.mat
-  }
+                 rsp.info = rsp.info,
+                 dist.mat <- dist.mat)
 
   event(type = "screen",
         "M: Analysis completed!")

--- a/R/residency.R
+++ b/R/residency.R
@@ -660,16 +660,10 @@ residency <- function(
   if (decision == "y") {
     event(type = c("screen", "report"),
           "M: Saving results as '", resultsname, "'.")
-    if (attributes(dist.mat)$valid)
-      save(detections, valid.detections, spatial, deployments, arrays, movements, valid.movements,
+    save(detections, valid.detections, spatial, deployments, arrays, movements, valid.movements,
         section.movements, status.df, last.seen, array.times, section.times, intra.array.matrices,
         residency.list, time.ratios, time.positions, global.ratios, group.ratios, efficiency,
         intra.array.CJS, rsp.info, dist.mat, file = resultsname)
-    else
-      save(detections, valid.detections, spatial, deployments, arrays, movements, valid.movements,
-        section.movements, status.df, last.seen, array.times, section.times, intra.array.matrices,
-        residency.list, time.ratios, time.positions, global.ratios, group.ratios, efficiency,
-        intra.array.CJS, rsp.info, file = resultsname)
   } else {
     event(type = c("screen", "report"),
           "M: Skipping saving of the results.")
@@ -883,10 +877,8 @@ residency <- function(
                  global.ratios = global.ratios,
                  group.ratios = group.ratios,
                  last.seen = last.seen,
-                 rsp.info = rsp.info)
-
-  if (attributes(dist.mat)$valid)
-    output$dist.mat <- dist.mat
+                 rsp.info = rsp.info,
+                 dist.mat <- dist.mat)
 
   event(type = "screen",
         "M: Analysis completed!")

--- a/R/residency.R
+++ b/R/residency.R
@@ -878,7 +878,7 @@ residency <- function(
                  group.ratios = group.ratios,
                  last.seen = last.seen,
                  rsp.info = rsp.info,
-                 dist.mat <- dist.mat)
+                 dist.mat = dist.mat)
 
   event(type = "screen",
         "M: Analysis completed!")

--- a/tests/testthat/test_explore.R
+++ b/tests/testthat/test_explore.R
@@ -187,7 +187,7 @@ test_that("explore is able to run speed and inactiveness checks.", {
 	file.remove("distances.csv")
 	output <- suppressWarnings(explore(tz = 'Europe/Copenhagen', report = TRUE, GUI = "never", speed.warning = 1000000, inactive.warning = 1000000))
 	expect_false(any(is.na(match(names(output), c('bio', 'detections', 'valid.detections', 'spatial', 'deployments', 'arrays',
-    'movements', 'valid.movements', 'times', 'rsp.info')))))
+    'movements', 'valid.movements', 'times', 'rsp.info','dist.mat')))))
 })
 # n
 # n

--- a/tests/testthat/test_migration.R
+++ b/tests/testthat/test_migration.R
@@ -140,7 +140,7 @@ test_that("migration is able to run speed and inactiveness checks.", {
 			GUI = "never", speed.error = 1000000, inactive.error = 1000000),
 		"Running inactiveness checks without a distance matrix. Performance may be limited.", fixed = TRUE)
 	
-	expect_false(any(is.na(match(names(output), c('arrays', 'deployments', 'detections', 'group.overview', 'intra.array.CJS',
+	expect_false(any(is.na(match(names(output), c('arrays', 'deployments', 'detections', 'dist.mat', 'group.overview', 'intra.array.CJS',
 	 'intra.array.matrices','matrices', 'movements', 'overall.CJS', 'release.overview', 'rsp.info', 'section.movements',
 	  'section.overview', 'spatial', 'status.df', 'times', 'valid.detections', 'valid.movements')))))
 })

--- a/tests/testthat/test_residency.R
+++ b/tests/testthat/test_residency.R
@@ -51,7 +51,7 @@ test_that("residency is able to run speed and inactiveness checks.", {
 			GUI = "never", speed.error = 1000000, inactive.error = 1000000),
 		"Running inactiveness checks without a distance matrix. Performance may be limited.", fixed = TRUE)
 	expect_false(any(is.na(match(names(output), c('array.times', 'arrays', 'time.positions', 'time.ratios',
-		'deployments', 'detections', 'efficiency', 'global.ratios', 'group.ratios', 'intra.array.CJS', 'intra.array.matrices',
+		'deployments', 'detections', 'dist.mat', 'efficiency', 'global.ratios', 'group.ratios', 'intra.array.CJS', 'intra.array.matrices',
 		'last.seen', 'movements', 'residency.list', 'rsp.info', 'section.movements', 'section.times',
 		'spatial', 'status.df', 'valid.detections', 'valid.movements')))))
 })


### PR DESCRIPTION
Minor changes to explore(), residency(), and migration() code to keep distance matrix when it is invalid but denote it with NA instead of an actual matrix of distances. 

Once merged, this fixes issue #142 